### PR TITLE
read iWindOrig from full dump files

### DIFF
--- a/src/main/readwrite_dumps_fortran.f90
+++ b/src/main/readwrite_dumps_fortran.f90
@@ -306,7 +306,7 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
        !                               i_real  = 6, &
        !                               i_real4 = 7, &
        !                               i_real8 = 8
-       if (k==8) !needed since we want to write as double precision reals
+       if (k==8) then !needed since we want to write as double precision reals
           if (ipass==1) then
              !nums(imatch,ib) = nums(imatch,ib) + 1
              nums(8,1) = nums(8,1) + 1

--- a/src/main/readwrite_dumps_fortran.f90
+++ b/src/main/readwrite_dumps_fortran.f90
@@ -1022,7 +1022,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  logical               :: got_eosvars(maxeosvars),got_nucleation(n_nucleation),got_ray_tracer
  logical               :: got_psi,got_Tdust,got_dustprop(2),got_VrelVf,got_dustgasprop(4)
  logical               :: got_filfac,got_divcurlv(4),got_rad(maxirad),got_radprop(maxradprop),got_pxyzu(4),got_iorig
-LOGICAL :: got_iwindorig
+ logical               :: got_iwindorig
  character(len=lentag) :: tag,tagarr(64)
  integer :: k,i,iarr,ik,ndustfraci
  real, allocatable :: tmparray(:)

--- a/src/main/readwrite_dumps_fortran.f90
+++ b/src/main/readwrite_dumps_fortran.f90
@@ -1055,7 +1055,8 @@ end subroutine read_smalldump_fortran
 subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,npartoftype,&
                                massoftype,nptmass,nsinkproperties,phantomdump,tagged,singleprec,&
                                tfile,alphafile,idisk1,iprint,ierr)
- use dump_utils, only:read_array,match_tag
+ !use dump_utils, only:read_array,match_tag
+ use dump_utils, only:read_array,match_tag,read_array_real8_to_int4
  use dim,        only:use_dust,h2chemistry,maxalpha,maxp,gravity,maxgrav,maxvxyzu,do_nucleation, &
                       use_dustgrowth,maxdusttypes,ndivcurlv,maxphase,gr,store_dust_temperature,&
                       ind_timesteps,use_krome
@@ -1066,7 +1067,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
                       VrelVf,VrelVf_label,dustgasprop,dustgasprop_label,filfac,filfac_label,pxyzu,pxyzu_label,dust_temp, &
                       rad,rad_label,radprop,radprop_label,do_radiation,maxirad,maxradprop,ifluxx,ifluxy,ifluxz, &
                       nucleation,nucleation_label,n_nucleation,ikappa,tau,itau_alloc,tau_lucy,itauL_alloc,&
-                      ithick,ilambda,iorig,dt_in,krome_nmols,T_gas_cool
+                      ithick,ilambda,iorig,dt_in,krome_nmols,T_gas_cool,iwindorig
  use sphNGutils, only:mass_sphng,got_mass,set_gas_particle_mass
  use options,    only:use_porosity
  integer, intent(in)   :: i1,i2,noffset,narraylengths,nums(:,:),npartread,npartoftype(:),idisk1,iprint
@@ -1083,6 +1084,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  logical               :: got_eosvars(maxeosvars),got_nucleation(n_nucleation),got_ray_tracer
  logical               :: got_psi,got_Tdust,got_dustprop(2),got_VrelVf,got_dustgasprop(4)
  logical               :: got_filfac,got_divcurlv(4),got_rad(maxirad),got_radprop(maxradprop),got_pxyzu(4),got_iorig
+LOGICAL :: got_iwindorig
  character(len=lentag) :: tag,tagarr(64)
  integer :: k,i,iarr,ik,ndustfraci
  real, allocatable :: tmparray(:)
@@ -1118,6 +1120,7 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
  got_radprop     = .false.
  got_pxyzu       = .false.
  got_iorig       = .false.
+ got_iwindorig   = .false.
 
  ndustfraci = 0
  if (use_dust) allocate(tmparray(size(dustfrac,2)))
@@ -1201,6 +1204,10 @@ subroutine read_phantom_arrays(i1,i2,noffset,narraylengths,nums,npartread,nparto
                 call read_array(rad,rad_label,got_rad,ik,i1,i2,noffset,idisk1,tag,match,ierr)
                 call read_array(radprop,radprop_label,got_radprop,ik,i1,i2,noffset,idisk1,tag,match,ierr)
              endif
+
+IF(k==8) THEN
+CALL read_array_real8_to_int4(iwindorig, 'iWindOrig', got_iwindorig, ik,i1,i2,noffset,idisk1,tag,match,ierr)
+ENDIF
           case(2)
              call read_array(xyzmh_ptmass,xyzmh_ptmass_label,got_sink_data,ik,1,nptmass,0,idisk1,tag,match,ierr)
              call read_array(vxyz_ptmass, vxyz_ptmass_label, got_sink_vels,ik,1,nptmass,0,idisk1,tag,match,ierr)

--- a/src/main/readwrite_dumps_fortran.f90
+++ b/src/main/readwrite_dumps_fortran.f90
@@ -306,7 +306,7 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
        !                               i_real  = 6, &
        !                               i_real4 = 7, &
        !                               i_real8 = 8
-       if (k==8) theneded since we want to write as double precision reals
+       if (k==8) !needed since we want to write as double precision reals
           if (ipass==1) then
              !nums(imatch,ib) = nums(imatch,ib) + 1
              nums(8,1) = nums(8,1) + 1

--- a/src/main/readwrite_dumps_fortran.f90
+++ b/src/main/readwrite_dumps_fortran.f90
@@ -299,87 +299,25 @@ subroutine write_fulldump_fortran(t,dumpfile,ntotal,iorder,sphNG)
        endif
        !call write_array(1,iwindorig,'iWindOrig',npart,k,ipass,idump,nums,nerr)  !though this seems fine, Splash doesn't seem to read in integers, so try a hack (below) where values are converted to real before outputting
 
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-! hack to write iwindorg as reals to dump file !
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-! stems from write_array_real8 in utils_dumpfiles.f90
-
-!                               i_real  = 6, &
-!                               i_real4 = 7, &
-!                               i_real8 = 8
-!
-! ...
-!
-!!---------------------------------------------------------------------
-!!+
-!!  Write real*4 array to block header (ipass=1) or to file (ipass=2)
-!!+
-!!---------------------------------------------------------------------
-!subroutine
-!write_array_real8(ib,arr,my_tag,len,ikind,ipass,iunit,nums,nerr,func,use_kind,singleprec)
-! real(kind=8),     intent(in) :: arr(:)
-! character(len=*), intent(in) :: my_tag
-! integer, intent(in)    :: ib,len,ikind,ipass,iunit
-! integer, intent(inout) :: nums(:,:)
-! integer, intent(inout) :: nerr
-! interface
-!  real(kind=8) pure function func(x)
-!   real(kind=8), intent(in) :: x
-!  end function func
-! end interface
-! optional :: func
-! !real(kind=8), optional :: func
-! integer, intent(in), optional :: use_kind
-! logical, intent(in), optional :: singleprec
-! integer :: i,imatch,ierr
-! logical :: use_singleprec
-!
-! ierr = 0
-! use_singleprec = .false.
-! if (present(singleprec)) use_singleprec = singleprec
-! ! use default real if it matches, unless kind is specified
-! if ((kind(0.)==8 .or. use_singleprec).and.(.not.present(use_kind))) then
-!    imatch = i_real
-! elseif (present(use_kind)) then
-!    if (use_kind==4) then
-!       imatch = i_real4
-!    else
-!       imatch = i_real8
-!    endif
-! else
-!    imatch = i_real8
-! endif
-! ! check if kind matches
-! if (ikind==imatch) then
-IF(k==8) THEN !needed since we want to write as double precision reals
-!    !print*,ipass,' WRITING ',my_tag,' as ',imatch,use_singleprec
-    if (ipass==1) then
-!       nums(imatch,ib) = nums(imatch,ib) + 1
-       nums(8,1) = nums(8,1) + 1
-    elseif (ipass==2) then
-!       write(iunit,iostat=ierr) tag(my_tag)
-       write(idump,iostat=ierr) tag('iWindOrig')
-!       if (present(func)) then
-!          write(iunit,iostat=ierr) (func(arr(i)),i=1,len)
-!       else
-!          if (imatch==i_real4 .or. use_singleprec) then
-!             write(iunit,iostat=ierr) (real(arr(i),kind=4),i=1,len)
-!          else
-!             write(iunit,iostat=ierr) arr(1:len)
+       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+       ! hack to write iwindorg as reals to dump file !
+       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+       ! stems from write_array_real8 in utils_dumpfiles.f90
+       !                               i_real  = 6, &
+       !                               i_real4 = 7, &
+       !                               i_real8 = 8
+       if (k==8) theneded since we want to write as double precision reals
+          if (ipass==1) then
+             !nums(imatch,ib) = nums(imatch,ib) + 1
+             nums(8,1) = nums(8,1) + 1
+          elseif (ipass==2) then
+             write(idump,iostat=ierr) tag('iWindOrig')
              write(idump,iostat=ierr) iwindorig(1:npart)*1.d0
-!          endif
-!       endif
-    endif
-ENDIF
-! endif
-! if (ierr /= 0) nerr = nerr + 1
-!
-!end subroutine write_array_real8
-
-!!!!!!!!!!!!!!!
-! end of hack !
-!!!!!!!!!!!!!!!
+          endif
+       endif
+       !!!!!!!!!!!!!!!
+       ! end of hack !
+       !!!!!!!!!!!!!!!
 
        if (nerr > 0) call error('write_dump','error writing hydro arrays')
     enddo
@@ -1205,9 +1143,17 @@ LOGICAL :: got_iwindorig
                 call read_array(radprop,radprop_label,got_radprop,ik,i1,i2,noffset,idisk1,tag,match,ierr)
              endif
 
-IF(k==8) THEN
-CALL read_array_real8_to_int4(iwindorig, 'iWindOrig', got_iwindorig, ik,i1,i2,noffset,idisk1,tag,match,ierr)
-ENDIF
+             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+             ! hack to read iwindorg as reals from full dump file !
+             !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+             !iWindOrig (or iwindorig) is a special case since this int*4 array is stored as real*8 in the full dump files
+             if (k==8) then
+                call read_array_real8_to_int4(iwindorig, 'iWindOrig', got_iwindorig, ik,i1,i2,noffset,idisk1,tag,match,ierr)
+                write(*,'(A,L)' 'got_iwindorig =',got_iwindorig
+             endif
+             !!!!!!!!!!!!!!!
+             ! end of hack !
+             !!!!!!!!!!!!!!!
           case(2)
              call read_array(xyzmh_ptmass,xyzmh_ptmass_label,got_sink_data,ik,1,nptmass,0,idisk1,tag,match,ierr)
              call read_array(vxyz_ptmass, vxyz_ptmass_label, got_sink_vels,ik,1,nptmass,0,idisk1,tag,match,ierr)

--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -153,7 +153,7 @@ module dump_utils
    read_array_real8, read_array_real8arr
  end interface read_array
 
-PUBLIC :: read_array_real8_to_int4
+ public :: read_array_real8_to_int4
 
  ! generic interface for reading arrays from dumpfile
  interface read_array_from_file
@@ -2361,7 +2361,7 @@ end subroutine read_array_real8arr
 !--------------------------------------------------------------------
 subroutine read_array_real8_to_int4(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,matched,ierr)
  !real(kind=8),     intent(inout) :: arr(:)
- INTEGER(KIND=4),  intent(inout) :: arr(:)
+ integer(kind=4),  intent(inout) :: arr(:)
  character(len=*), intent(in)    :: arr_tag,tag
  logical,          intent(inout) :: got_arr
  integer,          intent(in)    :: ikind,i1,i2,noffset,iunit

--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -2350,6 +2350,9 @@ subroutine read_array_real8arr(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag
 
 end subroutine read_array_real8arr
 
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! hack to read iwindorg as reals from full dump file !
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !--------------------------------------------------------------------
 !+
 !  Routine for extracting real*8 array from main block in dump file
@@ -2369,7 +2372,7 @@ subroutine read_array_real8_to_int4(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iuni
  real(kind=4) :: dumr4
  real(kind=4), allocatable :: dummyr4(:)
  logical      :: match_datatype
- REAL(KIND=8), ALLOCATABLE :: dummyr8(:)
+ real(kind=8), allocatable :: dummyr8(:)
 
  if (matched .or. ikind < i_real) return
  match_datatype = (ikind==i_real8 .or. (kind(0.)==8 .and. ikind==i_real))
@@ -2383,15 +2386,15 @@ subroutine read_array_real8_to_int4(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iuni
           ierr = ierr_arraysize
           return
        endif
-       !read(iunit,iostat=ierr) (dum,i=1,noffset),arr(i1:i2)
-!allocate real*8 data
+       !read(iunit,iostat=ierr) (dum,i=1,noffset),arr(i1:i2) !this is the old line that has been turned into the following 5 lines
+       !allocate real*8 data
        nread = i2-i1+1
        allocate(dummyr8(nread))
-!read in real*8 data
+       !read in real*8 data
        read(iunit,iostat=ierr) (dum,i=1,noffset),dummyr8(1:nread)
-!write to int*4 array
-       arr(i1:i2) = FLOOR(dummyr8(1:nread)+0.5d0,KIND=4)
-!deallocate real*8 data
+       !write to int*4 array
+       arr(i1:i2) = floor(dummyr8(1:nread)+0.5d0,kind=4)
+       !deallocate real*8 data
        deallocate(dummyr8)
     elseif (ikind==i_real4) then
        got_arr = .true.
@@ -2408,6 +2411,9 @@ subroutine read_array_real8_to_int4(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iuni
  endif
 
 end subroutine read_array_real8_to_int4
+!!!!!!!!!!!!!!!
+! end of hack !
+!!!!!!!!!!!!!!!
 
 !-----------------------------------------------------
 !+

--- a/src/main/utils_dumpfiles.f90
+++ b/src/main/utils_dumpfiles.f90
@@ -153,6 +153,8 @@ module dump_utils
    read_array_real8, read_array_real8arr
  end interface read_array
 
+PUBLIC :: read_array_real8_to_int4
+
  ! generic interface for reading arrays from dumpfile
  interface read_array_from_file
   module procedure read_array_from_file_r4, read_array_from_file_r8
@@ -2347,6 +2349,65 @@ subroutine read_array_real8arr(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag
  enddo
 
 end subroutine read_array_real8arr
+
+!--------------------------------------------------------------------
+!+
+!  Routine for extracting real*8 array from main block in dump file
+!  and putting the output into int*4 arrays
+!+
+!--------------------------------------------------------------------
+subroutine read_array_real8_to_int4(arr,arr_tag,got_arr,ikind,i1,i2,noffset,iunit,tag,matched,ierr)
+ !real(kind=8),     intent(inout) :: arr(:)
+ INTEGER(KIND=4),  intent(inout) :: arr(:)
+ character(len=*), intent(in)    :: arr_tag,tag
+ logical,          intent(inout) :: got_arr
+ integer,          intent(in)    :: ikind,i1,i2,noffset,iunit
+ logical,          intent(inout) :: matched
+ integer,          intent(out)   :: ierr
+ integer      :: i,nread
+ real(kind=8) :: dum
+ real(kind=4) :: dumr4
+ real(kind=4), allocatable :: dummyr4(:)
+ logical      :: match_datatype
+ REAL(KIND=8), ALLOCATABLE :: dummyr8(:)
+
+ if (matched .or. ikind < i_real) return
+ match_datatype = (ikind==i_real8 .or. (kind(0.)==8 .and. ikind==i_real))
+
+ if (match_tag(tag,arr_tag) .and. .not.matched) then
+    matched    = .true.
+    if (match_datatype) then
+       got_arr = .true.
+       if (i2 > size(arr)) then
+          print*,'ERROR: array size too small reading '//trim(tag),i2,size(arr)
+          ierr = ierr_arraysize
+          return
+       endif
+       !read(iunit,iostat=ierr) (dum,i=1,noffset),arr(i1:i2)
+!allocate real*8 data
+       nread = i2-i1+1
+       allocate(dummyr8(nread))
+!read in real*8 data
+       read(iunit,iostat=ierr) (dum,i=1,noffset),dummyr8(1:nread)
+!write to int*4 array
+       arr(i1:i2) = FLOOR(dummyr8(1:nread)+0.5d0,KIND=4)
+!deallocate real*8 data
+       deallocate(dummyr8)
+    elseif (ikind==i_real4) then
+       got_arr = .true.
+       !print*,'WARNING: converting '//trim(tag)//' from real*4'
+       nread = i2-i1+1
+       allocate(dummyr4(nread))
+       read(iunit,iostat=ierr) (dumr4,i=1,noffset),dummyr4(1:nread)
+       arr(i1:i2) = real(dummyr4(1:nread),kind=8)
+       deallocate(dummyr4)
+    else
+       print*,'ERROR: wrong datatype for '//trim(tag)//' (is not real8)'
+       read(iunit,iostat=ierr)
+    endif
+ endif
+
+end subroutine read_array_real8_to_int4
 
 !-----------------------------------------------------
 !+


### PR DESCRIPTION
Type of PR:
modification to existing code

Description:
Added a utility function read_array_real8_to_int4 to read in the variable iWindOrig (or iwindorig), which is an int*4 array in the code but is stored as a real*8 array so Splash easily reads in the values. This utility function is called when other real*8 single-dimension arrays are read in within the read_phantom_arrays subroutine.

Testing:
Without this addition, restarting a job reset every iWindOrig value to 0. With this addition, the iWindOrig values correctly carried over, which was demonstrated by column density plots of only a select group of winds before and after a restart.

Did you run the bots? no

Did you update relevant documentation in the docs directory? no