### PR TITLE
Remove should-have-been-already-removed code

### DIFF
--- a/src/setup/setup_galcen_stars.f90
+++ b/src/setup/setup_galcen_stars.f90
@@ -36,13 +36,6 @@ module setup
  real :: m_SMBH = 4.28d6 ! mass of supermassive black hole (SMBH) in Msun
  real :: h_SMBH = 0.1d0 ! accretion radius of SMBH in arcsec at 8kpc
 
- write(lu,"(/,a)") '# resolution'
- call write_inopt(m_gas, 'm_gas','gas mass resolution in solar masses',lu,ierr2)
- call write_inopt(h_sink, 'h_sink','stellar wind injection radii (also sink particle radii for the stars) in arcsec at 8kpc',lu,ierr2)
-
- write(lu,"(/,a)") '# SMBH properties'
- call write_inopt(m_SMBH, 'm_SMBH','SMBH mass in solar masses',lu,ierr2)
- call write_inopt(h_SMBH, 'h_SMBH','SMBH accretion radius in arcsec at 8kpc',lu,ierr2)
  private
 
 contains


### PR DESCRIPTION
Type of PR: 
Bug fix

Description:
Code with the variables that are read in from galcen.setup was accidentally left in the galcen setup routine.  This pull request removes that code, allowing "make setup" to run correctly.

Testing:
I compiled the setup portion of the code, and now it works.

Did you run the bots? yes

Did you update relevant documentation in the docs directory? no