### PR TITLE
Stellar potential -- first implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ _build
 *.cmod
 *.ilm
 *.stb
-build/Makefile_setups_Orig
+build/Makefile*_Orig
 build/fort.[0-9]*
 jobs/
 scripts/output_bots.sh.txt
@@ -39,6 +39,7 @@ scripts/output_*bots*.txt
 src/*/*90_Orig*
 src/*/*90_Debug*
 src/main/cooling_solver.f90_PleaseDontLoseThisVersion
+src/main/force.F90_BeforeMajorDebug
 src/main/substepping.F90_TestOptions
 radiation-test01explicit.ev
 radiation-test01implicit.ev

--- a/build/Makefile
+++ b/build/Makefile
@@ -282,6 +282,10 @@ ifeq ($(CWB), yes)
     FPPFLAGS += -DCWB
 endif
 
+ifeq ($(STELLARPOTENTIAL), yes)
+    FPPFLAGS += -DSTELLARPOTENTIAL
+endif
+
 ifdef SRCTURB
     FPPFLAGS += -DDRIVING
 endif

--- a/build/Makefile
+++ b/build/Makefile
@@ -282,8 +282,8 @@ ifeq ($(CWB), yes)
     FPPFLAGS += -DCWB
 endif
 
-ifeq ($(STELLARPOTENTIAL), yes)
-    FPPFLAGS += -DSTELLARPOTENTIAL
+ifeq ($(STELLAR_POTENTIAL), yes)
+    FPPFLAGS += -DSTELLAR_POTENTIAL
 endif
 
 ifdef SRCTURB

--- a/build/Makefile_defaults_gfortran
+++ b/build/Makefile_defaults_gfortran
@@ -14,7 +14,8 @@
 FC= gfortran
 FFLAGS+= -O3 -Wall -Wno-unused-dummy-argument -frecord-marker=4 -g \
         -finline-functions-called-once -finline-limit=1500 -funroll-loops -ftree-vectorize \
-        -std=f2008 -fall-intrinsics
+        -std=f2008 -fall-intrinsics -ffree-line-length-512
+#        -std=f2008 -fall-intrinsics
 DBLFLAG= -fdefault-real-8 -fdefault-double-8
 DEBUGFLAG= -g -fcheck=all -ffpe-trap=invalid,zero,overflow -finit-real=nan -finit-integer=nan -fbacktrace
 KNOWN_SYSTEM=yes

--- a/build/Makefile_setups
+++ b/build/Makefile_setups
@@ -351,6 +351,7 @@ ifeq ($(SETUP), galcen)
     SETUPFILE= setup_galcen_stars.f90
     SRCINJECT= inject_galcen_winds.f90
     IND_TIMESTEPS=yes
+    STELLARPOTENTIAL=yes
     KNOWN_SETUP=yes
 endif
 

--- a/build/Makefile_setups
+++ b/build/Makefile_setups
@@ -351,7 +351,7 @@ ifeq ($(SETUP), galcen)
     SETUPFILE= setup_galcen_stars.f90
     SRCINJECT= inject_galcen_winds.f90
     IND_TIMESTEPS=yes
-    STELLARPOTENTIAL=yes
+    STELLAR_POTENTIAL=yes
     KNOWN_SETUP=yes
 endif
 

--- a/src/main/initial.F90
+++ b/src/main/initial.F90
@@ -668,7 +668,8 @@ subroutine startrun(infile,logfile,evfile,dumpfile,noread)
     ! (specifying nbinmax in init_inject leads to nbinmax getting overwritten...)
     !
     print "(/,a,i0,a)", ' setting nbinmax = ',nbinmax,' to nbinmax = 3 so particles are injected before the first output file is written at time=dtmax'
-    nbinmax = MAX(nbinmax,3)
+    !nbinmax = MAX(nbinmax,3)
+    nbinmax = 3
  endif
 
  if (nalpha >= 2) then

--- a/src/main/inject_galcen_winds.f90
+++ b/src/main/inject_galcen_winds.f90
@@ -89,7 +89,8 @@ subroutine init_inject(ierr)
  !
  ! display time to immediately verify whether this is a new sim or a restarting sim
  !
- print "(/,a,f/)", ' init_inject : time =',time
+ !print "(/,a,f/)", ' init_inject : time =',time
+ print "(/,a,g0/)", ' init_inject : time =',time
 
  !
  ! correlate pointmass postion/velocity/mass table and pointmass wind table
@@ -195,9 +196,11 @@ subroutine init_inject(ierr)
           if (abs(time_tpi(i_curr)-time)>tol_init_inject) then
              ! correct entry in total_particles_injected.dat for "time" was not found
              print "(a)", ' Warning: the correct entry in total_particles_injected.dat does not seem to exist!'
-             print "(a,f)", '    time =',time
+             !print "(a,f)", '    time =',time
+             print "(a,g0)", '    time =',time
              do i=1,i_curr
-                print "(a,i0,a,f)", '    time_tpi(',i,') =',time_tpi(i)
+                !print "(a,i0,a,f)", '    time_tpi(',i,') =',time_tpi(i)
+                print "(a,i0,a,g0)", '    time_tpi(',i,') =',time_tpi(i)
              enddo
              print "(a)", ' total_particles_injected will be computed using "time".'
 
@@ -263,7 +266,8 @@ subroutine init_inject(ierr)
              tpi_read_from_file = .true. !correct entry for current restart time was found in total_particles_injected.dat
              !                           !   --> don't use total_particles_injected values computed above
              print "(a)", ' correct entry in total_particles_injected.dat has been found'
-             print "(a,f,a,f,2(a,i0),a)", ' time = ',time,', time_tpi(correct) = ',time_tpi(i_curr),', correct index i_curr = ',i_curr,' (out of ',j,')'
+             !print "(a,f,a,f,2(a,i0),a)", ' time = ',time,', time_tpi(correct) = ',time_tpi(i_curr),', correct index i_curr = ',i_curr,' (out of ',j,')'
+             print "(a,g0,a,g0,2(a,i0),a)", ' time = ',time,', time_tpi(correct) = ',time_tpi(i_curr),', correct index i_curr = ',i_curr,' (out of ',j,')'
              print "(a,i0)", ' nptmass_tpi(correct) = ',nptmass_tpi(i_curr)
              if (nptmass/=nptmass_tpi(i_curr)) then
                 ! kill the sim via reporting an error if the number of pointmasses in total_particles_injected is incorrect
@@ -587,6 +591,9 @@ subroutine write_options_inject(iunit)
  call write_inopt(trim(datafile),'datafile','name of data file for wind injection',iunit)
  call write_inopt(outer_boundary,'outer_boundary','kill gas particles outside this radius',iunit)
 
+WRITE(*,*) 'write_options_inject: time =',time
+WRITE(*,*) 'write_options_inject: tiny(time) =',tiny(time)
+ if (.not.isnan(time)) then
  if (time>tiny(time)) then
     !
     ! write new entry in total_particles_injected.dat when each full dump is
@@ -597,6 +604,7 @@ subroutine write_options_inject(iunit)
     open(file='total_particles_injected.dat',unit=iunit_tpi,form='formatted',position='append')
     write(iunit_tpi,*) time,nptmass,total_particles_injected(1:nptmass)
     close(iunit_tpi)
+ endif
  endif
 
 end subroutine write_options_inject

--- a/src/main/inject_galcen_winds.f90
+++ b/src/main/inject_galcen_winds.f90
@@ -89,7 +89,6 @@ subroutine init_inject(ierr)
  !
  ! display time to immediately verify whether this is a new sim or a restarting sim
  !
- !print "(/,a,f/)", ' init_inject : time =',time
  print "(/,a,g0/)", ' init_inject : time =',time
 
  !
@@ -196,10 +195,8 @@ subroutine init_inject(ierr)
           if (abs(time_tpi(i_curr)-time)>tol_init_inject) then
              ! correct entry in total_particles_injected.dat for "time" was not found
              print "(a)", ' Warning: the correct entry in total_particles_injected.dat does not seem to exist!'
-             !print "(a,f)", '    time =',time
              print "(a,g0)", '    time =',time
              do i=1,i_curr
-                !print "(a,i0,a,f)", '    time_tpi(',i,') =',time_tpi(i)
                 print "(a,i0,a,g0)", '    time_tpi(',i,') =',time_tpi(i)
              enddo
              print "(a)", ' total_particles_injected will be computed using "time".'
@@ -266,7 +263,6 @@ subroutine init_inject(ierr)
              tpi_read_from_file = .true. !correct entry for current restart time was found in total_particles_injected.dat
              !                           !   --> don't use total_particles_injected values computed above
              print "(a)", ' correct entry in total_particles_injected.dat has been found'
-             !print "(a,f,a,f,2(a,i0),a)", ' time = ',time,', time_tpi(correct) = ',time_tpi(i_curr),', correct index i_curr = ',i_curr,' (out of ',j,')'
              print "(a,g0,a,g0,2(a,i0),a)", ' time = ',time,', time_tpi(correct) = ',time_tpi(i_curr),', correct index i_curr = ',i_curr,' (out of ',j,')'
              print "(a,i0)", ' nptmass_tpi(correct) = ',nptmass_tpi(i_curr)
              if (nptmass/=nptmass_tpi(i_curr)) then

--- a/src/main/inject_galcen_winds.f90
+++ b/src/main/inject_galcen_winds.f90
@@ -591,20 +591,16 @@ subroutine write_options_inject(iunit)
  call write_inopt(trim(datafile),'datafile','name of data file for wind injection',iunit)
  call write_inopt(outer_boundary,'outer_boundary','kill gas particles outside this radius',iunit)
 
-WRITE(*,*) 'write_options_inject: time =',time
-WRITE(*,*) 'write_options_inject: tiny(time) =',tiny(time)
- if (.not.isnan(time)) then
- if (time>tiny(time)) then
-    !
-    ! write new entry in total_particles_injected.dat when each full dump is
-    ! written,
-    !    which is needed for eliminating discrepancies in injected-particle
-    !    numbers when restarting
-    !
-    open(file='total_particles_injected.dat',unit=iunit_tpi,form='formatted',position='append')
-    write(iunit_tpi,*) time,nptmass,total_particles_injected(1:nptmass)
-    close(iunit_tpi)
- endif
+ if (.not.isnan(time)) then !prevents issues when a simulation starts while debugging flags (which are stricter than normal flags) are turned on
+    if (time>tiny(time)) then
+       !
+       ! write new entry in total_particles_injected.dat when each full dump is written,
+       !    which is needed for eliminating discrepancies in injected-particle numbers when restarting
+       !
+       open(file='total_particles_injected.dat',unit=iunit_tpi,form='formatted',position='append')
+       write(iunit_tpi,*) time,nptmass,total_particles_injected(1:nptmass)
+       close(iunit_tpi)
+    endif
  endif
 
 end subroutine write_options_inject

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -215,6 +215,9 @@ subroutine get_accel_sink_gas(nptmass,xi,yi,zi,hi,xyzmh_ptmass,fxi,fyi,fzi,phi, 
        dz     = zi - xyzmh_ptmass(3,j)
     endif
     pmassj = xyzmh_ptmass(4,j)
+#ifdef STELLARPOTENTIAL
+    pmassj = pmassj * 2.
+#endif
     hsoft  = xyzmh_ptmass(ihsoft,j)
     J2     = xyzmh_ptmass(iJ2,j)
     if (hsoft > 0.0) hsoft = max(hsoft,hi)

--- a/src/main/ptmass.F90
+++ b/src/main/ptmass.F90
@@ -246,7 +246,7 @@ subroutine get_accel_sink_gas(nptmass,xi,yi,zi,hi,xyzmh_ptmass,fxi,fyi,fzi,phi, 
        !CuspMass = 6.e5 Msun
        !CuspAlpha1 = 1.6
        !CuspAlpha2 = 1.0
-       !if(r<=CuspRadius)
+       !if (r<=CuspRadius)
        !   mass_extra = CuspMass * (r/CuspRadius)^CuspAlpha1
        !else
        !   mass_extra = CuspMass * ((r/CuspRadius)^CuspAlpha2 * CuspAlpha1/CuspAlpha2 + 1.d0 - CuspAlpha1/CuspAlpha2)
@@ -335,7 +335,7 @@ subroutine get_accel_sink_gas(nptmass,xi,yi,zi,hi,xyzmh_ptmass,fxi,fyi,fzi,phi, 
        ! timestep is sqrt(separation/force)
        fonrmax = max(f1,f2,fonrmax)
        if (kappa) then
-          if(abs(bin_info(isemi,j))>tiny(f2)) then
+          if (abs(bin_info(isemi,j))>tiny(f2)) then
              bin_info(ipert,j) = bin_info(ipert,j) + f2
           endif
        endif
@@ -530,7 +530,7 @@ subroutine get_accel_sink_sink(nptmass,xyzmh_ptmass,fxyz_ptmass,phitot,dtsinksin
           !CuspMass = 6.e5 Msun
           !CuspAlpha1 = 1.6
           !CuspAlpha2 = 1.0
-          !if(r<=CuspRadius)
+          !if (r<=CuspRadius)
           !   mass_extra = CuspMass * (r/CuspRadius)^CuspAlpha1
           !else
           !   mass_extra = CuspMass * ((r/CuspRadius)^CuspAlpha2 * CuspAlpha1/CuspAlpha2 + 1.d0 - CuspAlpha1/CuspAlpha2)
@@ -908,7 +908,7 @@ subroutine ptmass_accrete(is,nptmass,xi,yi,zi,hi,vxi,vyi,vzi,fxi,fyi,fzi, &
  integer            :: i,ifail
  real               :: dx,dy,dz,r2,dvx,dvy,dvz,v2,hacc
  logical, parameter :: iofailreason=.false.
- !LOGICAL, PARAMETER :: iofailreason=.true.
+ !logical, parameter :: iofailreason=.true.
  integer            :: j
  real               :: mpt,tbirthi,drdv,angmom2,angmomh2,epart,dxj,dyj,dzj,dvxj,dvyj,dvzj,rj2,vj2,epartj
  logical            :: mostbound
@@ -925,8 +925,8 @@ subroutine ptmass_accrete(is,nptmass,xi,yi,zi,hi,vxi,vyi,vzi,fxi,fyi,fzi, &
     !   !write(iprint,"(/,a)") 'ptmass_accrete: FAILED: particle is not an accretable type'
     !   write(iprint,"(/,a,I3,L2)") 'ptmass_accrete: FAILED: particle is not an accretable type',itypei,is_accretable(itypei)
     return
-!ELSE
-!WRITE(*,*) 'ptmass_accrete: is accretable',itypei,is_accretable(itypei)
+    !else
+    !   write(*,*) 'ptmass_accrete: is accretable',itypei,is_accretable(itypei)
  endif
  !
  sinkloop : do i=is,nptmass
@@ -1007,14 +1007,14 @@ subroutine ptmass_accrete(is,nptmass,xi,yi,zi,hi,vxi,vyi,vzi,fxi,fyi,fzi, &
        case(2)
           write(iprint,"(/,a,Es9.2,a,Es9.2)") 'ptmass_accrete: FAILED: angular momentum is too large: ' &
                                               ,angmom2,' > ',angmomh2
-       !case(1)
-       !   write(iprint,"(/,a)") 'ptmass_accrete: FAILED: r2 > hacc**2'
+          !case(1)
+          !   write(iprint,"(/,a)") 'ptmass_accrete: FAILED: r2 > hacc**2'
        case(-1)
           write(iprint,"(/,a)") 'ptmass_accrete: PASSED indiscriminately: particle will be accreted'
        case(-2)
           write(iprint,"(/,a)") 'ptmass_accrete: PASSED: particle will be accreted'
-       !case default
-       !   write(iprint,"(/,a)") 'ptmass_accrete: FAILED: unknown reason'
+          !case default
+          !   write(iprint,"(/,a)") 'ptmass_accrete: FAILED: unknown reason'
        end select
     endif
     if (present(nfaili)) nfaili = ifail


### PR DESCRIPTION
Type of PR: 
new physics

Description:
Added the stellar potential to the GC galcen simulations.  For this first implementation, this is done by increasing the mass in `pmassj` when j=SMBH for both the `get_accel_sink_gas()` and `get_accel_sink_sink()` subroutines in ptmass.F90.  In the sink-sink routine, the stellar potential could have been done as an external force via a new type of call to `exernalforce()`, but I didn't see the same formalism setup already for the gas-sink interaction, so I went with modyfing the SMBH's `pmassj`.

Presently, the Cuadra+08, Cuadra+15, etc. stellar potential is hardwired into the code, which takes the following form:
```
       !This is the stellar potential that was implemented in Cuadra+08, Cuadra+15, etc.
       !CuspRadius = 0.4 pc
       !CuspMass = 6.e5 Msun
       !CuspAlpha1 = 1.6
       !CuspAlpha2 = 1.0
       !if(r<=CuspRadius)
       !   mass_extra = CuspMass * (r/CuspRadius)^CuspAlpha1
       !else
       !   mass_extra = CuspMass * ((r/CuspRadius)^CuspAlpha2 * CuspAlpha1/CuspAlpha2 + 1.d0 - CuspAlpha1/CuspAlpha2)
       !endif
       !Note: since CuspAlpha2=1, the r>CuspRadius expression is simplified as follows
       !   mass_extra = CuspMass * ((r/CuspRadius)^1 * 1.6/1 + 1.d0 - 1.6/1)
       !   mass_extra = CuspMass * (r/CuspRadius * 1.6 - 0.6)
       !Note: variable rrsp is defined as rrsp=r/CuspRadius
```

The stellar potential is implemented using the preprocessor directive `STELLAR_POTENTIAL=yes`, which is now the default option for galcen sims via build/Makefile_setups.  To turn this off, compile with anything but `STELLAR_POTENTIAL=yes`; for example, use `STELLAR_POTENTIAL=no`, `STELLAR_POTENTIAL=asdf`, `STELLAR_POTENTIAL=`, etc., to turn off the stellar potential.

Additionally, lines of code can be up to 512 characters in length before a compilation error is given with gfortran, which was done via adding the compiler option `-ffree-line-length-512` to `FFLAGS` in Makefile_defaults_gfortran.

Testing:
I ran the code with and without the stellar potential to compare to previous GC sims.  The consistency among the stars with Gadget sims that do and do not use the stellar potential has been confirmed; this is easy to do with all mass-loss rates set to 0 in winddata.txt.  To be confirmed is the gas consistency, which will take several days for the Gadget-equivalent sims to run.

Did you run the bots? yes.  Now the entirety of files ptmass.F90 and inject_galcen_winds.f90 are bot compliant.

Did you update relevant documentation in the docs directory? no